### PR TITLE
fix call unicodeProgressBar param's value > 100

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -18,5 +18,5 @@ jobs:
         run: node ./index.js
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          GIST_ID: 97b738c515448231e85fc48014be5b3b
+          GIST_ID: 1430cb62f20dba7e1ef0f973a658a7c0
           WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function unicodeProgressBar(p, style = 7, min_size = 20, max_size = 20) {
   const bar_style = bar_styles[style];
   const full_symbol = bar_style[bar_style.length - 1];
   const n = bar_style.length - 1;
-  if (p === 100) return full_symbol.repeat(max_size);
+  if (p >= 100) return full_symbol.repeat(max_size);
 
   p = p / 100;
   for (let i = max_size; i >= min_size; i--) {


### PR DESCRIPTION
my data：
```js
{
  decimal: '1.42',
  digital: '1:25',
  hours: 1,
  minutes: 25,
  name: 'TypeScript',
  percent: 99.1,
  text: '1 hr 25 mins',
  total_seconds: 5140.988058
}
```
In my case , `percent: 99.1`, However, when calling `unicodeProgressBar`, [the argument is default increment 15](https://github.com/antfu/waka-box/blob/a139d161da3eaca513e5ed9d091f5dc6f26266c0/index.js#L36)

This causes the condition [p===100](https://github.com/antfu/waka-box/blob/a139d161da3eaca513e5ed9d091f5dc6f26266c0/index.js#L91) not to be triggered.

In this case, [i - full - 1](https://github.com/antfu/waka-box/blob/a139d161da3eaca513e5ed9d091f5dc6f26266c0/index.js#L105) is an negative number, and the following error is reported:
```
C:\Users\DM\Documents\GitHub\waka-box\index.js:107
      r = full_symbol.repeat(full) + m + bar_style[0].repeat(i - full - 1);
                                                      ^

RangeError: Invalid count value
    at String.repeat (<anonymous>)
    at unicodeProgressBar (C:\Users\DM\Documents\GitHub\waka-box\index.js:107:55)
    at updateGist (C:\Users\DM\Documents\GitHub\waka-box\index.js:36:7)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async main (C:\Users\DM\Documents\GitHub\waka-box\index.js:17:3)
    at async C:\Users\DM\Documents\GitHub\waka-box\index.js:114:3
```



